### PR TITLE
travis-ci: Linux-only, apt dependencies, build-only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: shell
+os: linux
+dist: bionic
+git:
+  depth: 1
+addons:
+  apt:
+    update: true
+    packages:
+      - luajit
+      - luarocks
+      - zlib1g-dev
+      - libvips-dev
+script: luajit make.lua build


### PR DESCRIPTION
More to come for uploading artifacts and other platforms.

To activate Travis CI, log in with your GitHub account via OAuth at https://travis-ci.com/ and follow the instructions to set it up for this repository. It should be fairly straightforward.